### PR TITLE
Fix music lib bot discography playlist

### DIFF
--- a/src/app/music_lib_bot.py
+++ b/src/app/music_lib_bot.py
@@ -351,6 +351,8 @@ class MusicLibBot:
     def _get_artist_from_user(self):
         artist_name = self.ui.get_non_empty_string("What artist interests you?")
         matching_artists = self.music_api_client.get_matching_artists(artist_name)
+        exact_matching_artists = self.music_util.filter_exact_matches(artist_name, matching_artists)
+        matching_artists = matching_artists if len(exact_matching_artists) == 0 else exact_matching_artists
         if matching_artists == []:
             self.ui.tell_user(f"Sorry, I couldn't find an artist by the name '{artist_name}'")
             return None

--- a/src/packages/music_management/music_util.py
+++ b/src/packages/music_management/music_util.py
@@ -2,6 +2,8 @@ from collections import defaultdict
 from re import match
 from packages.music_api_clients.models.audio_features import AudioFeatures
 from packages.music_api_clients.models.song_attribute_ranges import SongAttributeRanges
+from packages.music_api_clients.models.artist import Artist
+from typing import List
 
 
 class MusicUtil:
@@ -180,6 +182,13 @@ class MusicUtil:
             for track in playlist.get_tracks()
             for artist in track.artists
         })
+
+    def filter_exact_matches(self, artist_name: str, artists: List["Artist"]):
+        return [
+            artist
+            for artist in artists
+            if artist.name.lower().strip() == artist_name.lower().strip()
+        ]
 
     def order_albums_chronologically(self, albums):
         return sorted(albums, key=lambda album: album.release_date)

--- a/src/scripts/create_playlist_from_artists_discography.py
+++ b/src/scripts/create_playlist_from_artists_discography.py
@@ -1,0 +1,32 @@
+# allows me to run:
+# $ python scripts/this_script.py
+import sys
+sys.path.extend(['.', '../'])
+
+from packages.music_management.music_util import MusicUtil
+from packages.music_management.my_music_lib import MyMusicLib
+from packages.music_api_clients.spotify import Spotify
+from packages.music_api_clients.models.artist import Artist
+from packages.music_management.playlist_creator import PlaylistCreator
+
+
+def main():
+    spotify = Spotify()
+    music_util = MusicUtil(spotify, print)
+    my_music_lib = MyMusicLib(spotify, music_util, print)
+
+    PlaylistCreator(
+        spotify,
+        my_music_lib,
+        music_util,
+        print,
+    ).create_playlist_from_an_artists_discography(
+        # https://open.spotify.com/artist/0tIODqvzGUoEaK26rK4pvX?si=8pEfwJ9ASkeB0-34aPx5xw
+        lambda: Artist("Sun Ra", spotify_id="0tIODqvzGUoEaK26rK4pvX"),
+        lambda: 1,
+        lambda: "Test Playlist - Sun Ra Discography",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/run_music_lib_bot_create_playlist_from_an_artists_discography.py
+++ b/src/scripts/run_music_lib_bot_create_playlist_from_an_artists_discography.py
@@ -1,0 +1,24 @@
+# allows me to run:
+# $ python scripts/this_script.py
+import sys
+sys.path.extend(['.', '../'])
+
+from app.lib.console_ui import ConsoleUI
+from app.music_lib_bot import MusicLibBot
+from packages.music_management.music_util import MusicUtil
+from packages.music_management.my_music_lib import MyMusicLib
+from packages.music_api_clients.spotify import Spotify
+
+
+def main():
+    spotify = Spotify()
+    ui = ConsoleUI()
+    music_util = MusicUtil(spotify, ui.tell_user)
+    my_music_lib = MyMusicLib(spotify, music_util, ui.tell_user)
+    music_lib_bot = MusicLibBot(spotify, my_music_lib, music_util, ui)
+
+    music_lib_bot.run_create_playlist_from_an_artists_discography()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Changes only affect `MusicLibBot.run_create_playlist_from_an_artists_discography`, which I've tested.

Fixes this issue:
```
Here are your options:
(0): Create playlist from an artist's discography.
(1): Create playlist from a playlist full of albums.
(2): Update target playlists from seed playlists.
(3): Create playlist from albums in your library that have matching genres.
(4): Update existing playlist with tracks from my saved albums with similar genres.
(5): Update existing playlist with recommended tracks with similar attributes.

> Pick an option!
Enter a number between 0 and 5 or enter -1 to quit:
0
Let's create a playlist from an artist's discography.

> What artist interests you?
Sun Ra
I found: Ramana Gogula, Sunitha, with genres ['classic tollywood'], with popularity 49

Here are your options:
(0): Create playlist from an artist's discography.
(1): Create playlist from a playlist full of albums.
(2): Update target playlists from seed playlists.
(3): Create playlist from albums in your library that have matching genres.
(4): Update existing playlist with tracks from my saved albums with similar genres.
(5): Update existing playlist with recommended tracks with similar attributes.
```